### PR TITLE
Scroll reveal animations, and fix the nav bar appearing late

### DIFF
--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -126,19 +126,36 @@ test('every section is fully visible after being scrolled to', async ({ page }) 
   await page.setViewportSize(DESKTOP);
   await gotoHome(page);
 
+  const opacityOf = (id: string) =>
+    page.evaluate((sectionId) => {
+      const el = document.getElementById(sectionId);
+      return el ? parseFloat(getComputedStyle(el).opacity) : null;
+    }, id);
+
   for (const id of CLIPPABLE_SECTION_IDS) {
     await page.locator(`#${id}`).scrollIntoViewIfNeeded();
     await expect
-      .poll(
-        () =>
-          page.evaluate((sectionId) => {
-            const el = document.getElementById(sectionId);
-            return el ? parseFloat(getComputedStyle(el).opacity) : null;
-          }, id),
-        { message: `section #${id} never finished revealing`, timeout: 4000 },
-      )
+      .poll(() => opacityOf(id), {
+        message: `section #${id} never finished revealing`,
+        timeout: 4000,
+      })
       .toBe(1);
   }
+
+  // The reveal only fires once a section's top edge is 25% of the way up the
+  // window, which is unreachable for anything close enough to the end of the
+  // document that the page runs out of scroll first. Nothing can rescue such a
+  // section -- it would simply never appear -- so the last one gets checked at
+  // the actual bottom of the page rather than at whatever position
+  // `scrollIntoViewIfNeeded` happens to pick.
+  const last = CLIPPABLE_SECTION_IDS[CLIPPABLE_SECTION_IDS.length - 1];
+  await page.evaluate(() => window.scrollTo({ top: 1e7, behavior: 'instant' }));
+  await expect
+    .poll(() => opacityOf(last), {
+      message: `section #${last} is still hidden at the very bottom of the page`,
+      timeout: 4000,
+    })
+    .toBe(1);
 });
 
 test('the nav bar appears as the hero arrow leaves, not before or long after', async ({ page }) => {

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -110,10 +110,64 @@ test('no section card clips its own content', async ({ page }) => {
     }, id);
 
     expect(overflowPx, `section #${id} should render, found no .MuiCard-root child`).not.toBeNull();
-    expect(overflowPx, `section #${id} clips ${overflowPx}px of its own content`).toBeLessThanOrEqual(
-      1,
-    );
+    expect(
+      overflowPx,
+      `section #${id} clips ${overflowPx}px of its own content`,
+    ).toBeLessThanOrEqual(1);
   }
+});
+
+test('every section is fully visible after being scrolled to', async ({ page }) => {
+  // The scroll-reveal animation starts sections at opacity 0. Its catastrophic
+  // failure mode is failing closed -- content that never reveals is content
+  // nobody can read, and no other check here would notice, since a hidden
+  // element still has a bounding box, still contains its text, and still
+  // reports the same scrollHeight.
+  await page.setViewportSize(DESKTOP);
+  await gotoHome(page);
+
+  for (const id of CLIPPABLE_SECTION_IDS) {
+    await page.locator(`#${id}`).scrollIntoViewIfNeeded();
+    await expect
+      .poll(
+        () =>
+          page.evaluate((sectionId) => {
+            const el = document.getElementById(sectionId);
+            return el ? parseFloat(getComputedStyle(el).opacity) : null;
+          }, id),
+        { message: `section #${id} never finished revealing`, timeout: 4000 },
+      )
+      .toBe(1);
+  }
+});
+
+test('the nav bar appears as the hero arrow leaves, not before or long after', async ({ page }) => {
+  await page.setViewportSize(DESKTOP);
+  await gotoHome(page);
+
+  const navVisibility = () =>
+    page.evaluate(() => {
+      const header = document.querySelector('header');
+      return header ? getComputedStyle(header.parentElement as Element).visibility : null;
+    });
+
+  // While the arrow is on screen the hero has its own nav, so the global bar
+  // must stay out of the way.
+  expect(await navVisibility()).toBe('hidden');
+
+  // Put the arrow just past the top of the viewport.
+  await page.evaluate(() => {
+    const arrow = document.querySelector('[data-scroll-indicator]') as HTMLElement;
+    const bottom = arrow.getBoundingClientRect().bottom + window.scrollY;
+    window.scrollTo({ top: bottom + 2, behavior: 'instant' });
+  });
+
+  await expect
+    .poll(navVisibility, {
+      message: 'nav bar did not appear once the arrow had gone',
+      timeout: 2000,
+    })
+    .toBe('visible');
 });
 
 test('contact form submits against a stubbed backend and shows the success state', async ({

--- a/frontend/src/components/AppShell/InternalComponents/NavBar.tsx
+++ b/frontend/src/components/AppShell/InternalComponents/NavBar.tsx
@@ -1,4 +1,4 @@
-import { Box, AppBar, Toolbar, Button, IconButton, Fade } from '@mui/material';
+import { Box, AppBar, Toolbar, Button, IconButton, useMediaQuery } from '@mui/material';
 import Menu from '@mui/icons-material/Menu';
 import { useShowNavBar } from './useShowNavBar';
 import { navLinks } from './navLinks';
@@ -10,63 +10,86 @@ interface NavBarProps {
 
 export const NavBar = ({ setSettingDrawer }: NavBarProps) => {
   const isVisible = useShowNavBar();
+  const prefersReducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
+  // 220ms in / 160ms out. This was a 1000ms `Fade`, which made the bar feel
+  // late even once `useShowNavBar` fired at the right moment -- a full second
+  // of fade means it is still nearly transparent a third of a second after the
+  // hero's arrow has gone. Chrome, not content: it should keep up with the
+  // scroll, not perform.
+  const enterMs = prefersReducedMotion ? 0 : 220;
+  const exitMs = prefersReducedMotion ? 0 : 160;
+  const duration = isVisible ? enterMs : exitMs;
+
   return (
-    <Fade in={isVisible} timeout={1000}>
-      <Box
-        sx={{
-          flexGrow: 1,
-          top: 0,
-          position: 'sticky',
-          // `position: sticky` always creates a stacking context, so the
-          // AppBar's own z-index is scoped inside this Box and cannot lift it
-          // above page content. At zIndex 1 the bar tied with MUI's input
-          // labels (also z-index 1) and lost on DOM order, letting the Name and
-          // Email labels show through. Match the theme's appBar layer instead.
-          zIndex: (theme) => theme.zIndex.appBar,
-          width: '100%',
-          transition: 'top 1.0s',
-          visibility: isVisible ? 'visible' : 'hidden',
-        }}
-      >
-        <AppBar sx={{ bgcolor: 'background.paper' }}>
-          <Toolbar>
-            {/* Icon-only, so the accessible name lives on the IconButton -- Logo
+    <Box
+      sx={{
+        flexGrow: 1,
+        top: 0,
+        position: 'sticky',
+        // `position: sticky` always creates a stacking context, so the
+        // AppBar's own z-index is scoped inside this Box and cannot lift it
+        // above page content. At zIndex 1 the bar tied with MUI's input
+        // labels (also z-index 1) and lost on DOM order, letting the Name and
+        // Email labels show through. Match the theme's appBar layer instead.
+        zIndex: (theme) => theme.zIndex.appBar,
+        width: '100%',
+        opacity: isVisible ? 1 : 0,
+        // Slides down from a hair above its resting place. `none` rather than
+        // `translateY(0)` when settled, so the bar stops being a containing
+        // block for anything inside it once the transition is over.
+        transform: isVisible || prefersReducedMotion ? 'none' : 'translateY(-10px)',
+        // `visibility` is what actually removes the hidden bar from the
+        // accessibility tree and the tab order -- opacity alone would leave a
+        // full row of invisible, focusable nav buttons over the hero. It has to
+        // switch instantly on the way in but wait for the fade on the way out,
+        // hence the delayed 0s step rather than a duration.
+        visibility: isVisible ? 'visible' : 'hidden',
+        transition: [
+          `opacity ${duration}ms ease`,
+          `transform ${duration}ms ease`,
+          `visibility 0s linear ${isVisible ? 0 : duration}ms`,
+        ].join(', '),
+        pointerEvents: isVisible ? 'auto' : 'none',
+      }}
+    >
+      <AppBar sx={{ bgcolor: 'background.paper' }}>
+        <Toolbar>
+          {/* Icon-only, so the accessible name lives on the IconButton -- Logo
                 itself stays decorative (no titleAccess) to avoid a duplicate
                 announcement, matching the pattern SidebarNav's collapsed rail
                 already uses for its own icon-only nav links. */}
-            <IconButton
-              aria-label="Alex Cash — go to top"
-              href="#landing"
-              sx={{ color: 'text.primary', mr: 1 }}
-            >
-              <Logo sx={{ fontSize: 28 }} />
-            </IconButton>
-            <Box
-              sx={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'space-evenly',
-                width: '100%',
-                flexWrap: 'wrap',
-              }}
-            >
-              {navLinks.map((link) => (
-                <Button
-                  key={link.id}
-                  variant="text"
-                  sx={{ color: 'text.primary' }}
-                  href={`#${link.id}`}
-                >
-                  {link.label}
-                </Button>
-              ))}
-            </Box>
-            <IconButton aria-label="Open Settings Drawer" onClick={() => setSettingDrawer(true)}>
-              <Menu sx={{ color: 'text.primary' }} />
-            </IconButton>
-          </Toolbar>
-        </AppBar>
-      </Box>
-    </Fade>
+          <IconButton
+            aria-label="Alex Cash — go to top"
+            href="#landing"
+            sx={{ color: 'text.primary', mr: 1 }}
+          >
+            <Logo sx={{ fontSize: 28 }} />
+          </IconButton>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-evenly',
+              width: '100%',
+              flexWrap: 'wrap',
+            }}
+          >
+            {navLinks.map((link) => (
+              <Button
+                key={link.id}
+                variant="text"
+                sx={{ color: 'text.primary' }}
+                href={`#${link.id}`}
+              >
+                {link.label}
+              </Button>
+            ))}
+          </Box>
+          <IconButton aria-label="Open Settings Drawer" onClick={() => setSettingDrawer(true)}>
+            <Menu sx={{ color: 'text.primary' }} />
+          </IconButton>
+        </Toolbar>
+      </AppBar>
+    </Box>
   );
 };

--- a/frontend/src/components/AppShell/InternalComponents/useShowNavBar.test.ts
+++ b/frontend/src/components/AppShell/InternalComponents/useShowNavBar.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useShowNavBar, SCROLL_INDICATOR_ATTR } from './useShowNavBar';
+
+/**
+ * These pin the two bugs the browser measurements found, both of which are
+ * invisible to a test that only asks "does the bar eventually appear".
+ */
+
+/** Stand-in for the hero's scroll indicator, with a position we control. */
+const mountIndicator = (bottom: number) => {
+  const el = document.createElement('div');
+  el.setAttribute(SCROLL_INDICATOR_ATTR, 'true');
+  el.getBoundingClientRect = vi.fn(() => ({ bottom }) as DOMRect);
+  document.body.appendChild(el);
+  return el;
+};
+
+/**
+ * Flushes the frame the hook schedules. Its `getBoundingClientRect` read is
+ * coalesced into a `requestAnimationFrame` -- one layout read per frame rather
+ * than one per scroll event -- so both the initial read and every scroll need a
+ * frame to pass before the result is observable.
+ */
+const flushFrame = async () => {
+  await act(async () => {
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+  });
+};
+
+const scroll = async () => {
+  await act(async () => {
+    window.dispatchEvent(new Event('scroll'));
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+  });
+};
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('useShowNavBar', () => {
+  it('stays hidden while the arrow is still on screen', async () => {
+    mountIndicator(400); // 400px below the viewport top, i.e. plainly visible
+    const { result } = renderHook(() => useShowNavBar());
+    await flushFrame();
+
+    expect(result.current).toBe(false);
+  });
+
+  it('shows the moment the arrow has gone past the top of the viewport', async () => {
+    const el = mountIndicator(400);
+    const { result } = renderHook(() => useShowNavBar());
+    await flushFrame();
+    expect(result.current).toBe(false);
+
+    // The arrow's bottom edge crosses y=0: it is now entirely above the fold.
+    el.getBoundingClientRect = vi.fn(() => ({ bottom: -1 }) as DOMRect);
+    await scroll();
+
+    expect(result.current).toBe(true);
+  });
+
+  it('stays hidden when the arrow is below the fold, however far down it sits', async () => {
+    // The regression this replaced: keying off "is the arrow invisible" instead
+    // of "has the arrow gone *upward*". On a window shorter than the hero the
+    // arrow starts below the fold -- equally invisible -- which put the bar over
+    // the hero before a single pixel of scrolling. Measured on a 700px window.
+    mountIndicator(1200);
+    const { result } = renderHook(() => useShowNavBar());
+    await flushFrame();
+    await scroll();
+
+    expect(result.current).toBe(false);
+  });
+
+  it('hides again when the visitor scrolls back up to the hero', async () => {
+    const el = mountIndicator(-1);
+    const { result } = renderHook(() => useShowNavBar());
+    await flushFrame();
+    expect(result.current).toBe(true);
+
+    el.getBoundingClientRect = vi.fn(() => ({ bottom: 200 }) as DOMRect);
+    await scroll();
+
+    expect(result.current).toBe(false);
+  });
+
+  it('falls back to the scroll-offset rule when there is no indicator to watch', async () => {
+    // The error page, and any test rendering the shell without Landing, have no
+    // arrow to key off. The bar must still appear rather than being stuck off.
+    Object.defineProperty(window, 'innerHeight', { value: 800, configurable: true });
+    Object.defineProperty(window, 'scrollY', { value: 0, configurable: true });
+
+    const { result } = renderHook(() => useShowNavBar());
+    expect(result.current).toBe(false);
+
+    Object.defineProperty(window, 'scrollY', { value: 2000, configurable: true });
+    await scroll();
+
+    expect(result.current).toBe(true);
+  });
+
+  it('removes its listeners on unmount', () => {
+    mountIndicator(400);
+    const remove = vi.spyOn(window, 'removeEventListener');
+    const { unmount } = renderHook(() => useShowNavBar());
+    unmount();
+
+    const removed = remove.mock.calls.map(([event]) => event);
+    expect(removed).toContain('scroll');
+    expect(removed).toContain('resize');
+    remove.mockRestore();
+  });
+});

--- a/frontend/src/components/AppShell/InternalComponents/useShowNavBar.ts
+++ b/frontend/src/components/AppShell/InternalComponents/useShowNavBar.ts
@@ -1,30 +1,69 @@
 import { useState, useEffect } from 'react';
 
 /**
- * Hook to show/hide the nav bar based on scroll position
+ * The hero's scroll-indicator arrow tags itself with this so the nav bar can
+ * key off the actual element rather than a guessed scroll offset. Landing owns
+ * the attribute; see Landing.tsx's scroll indicator.
+ */
+export const SCROLL_INDICATOR_ATTR = 'data-scroll-indicator';
+
+/**
+ * Whether the global `NavBar` should be showing.
+ *
+ * The rule is "as soon as the hero's down arrow has gone past the top of the
+ * screen" -- the arrow is the affordance saying there is more page, so the
+ * moment it leaves is the moment a nav is needed. That used to be approximated
+ * as `scrollY > innerHeight - 14`, which measures the *window*, not the arrow,
+ * so its error moved with the window height: measured against where the arrow
+ * actually goes, it fired 30px early on a 900px-tall window and 169px early on
+ * a 650px one. Reading the arrow's own position removes the guess and holds at
+ * every height.
+ *
+ * Deliberately a scroll listener rather than an `IntersectionObserver`. IO
+ * looks like the natural fit and was tried first, but it answers "is this
+ * visible", and the hero clips its own overflow -- so IO's notion of the arrow
+ * being gone arrives at a rect position that shifts with viewport height
+ * (measured: the arrow's rect was still 27px inside the viewport at 800px tall,
+ * and still *below* the viewport top at 700px, which left the bar stuck hidden
+ * forever). `bottom <= 0` is the unambiguous version of the same question.
+ *
+ * Falls back to the old offset rule when there is no indicator in the DOM (the
+ * error page, and any test that renders the shell without Landing), so the bar
+ * still appears there.
+ *
  * @returns {boolean} true if the nav bar is visible, false otherwise
  */
 export const useShowNavBar = () => {
   const [isVisible, setIsVisible] = useState(false);
 
   useEffect(() => {
-    const handleScroll = () => {
-      const scrollPosition = window.scrollY;
-      const threshold = window.innerHeight - 14;
-      if (scrollPosition > threshold) {
-        setIsVisible(true);
-      } else {
-        setIsVisible(false);
-      }
-    };
+    const indicator = document.querySelector(`[${SCROLL_INDICATOR_ATTR}]`);
 
-    window.addEventListener('scroll', handleScroll);
+    // One rAF-coalesced read per frame at most: `getBoundingClientRect` forces
+    // layout, and scroll events can outpace frames.
+    let frame = 0;
+    const handleScroll = indicator
+      ? () => {
+          if (frame) return;
+          frame = requestAnimationFrame(() => {
+            frame = 0;
+            setIsVisible(indicator.getBoundingClientRect().bottom <= 0);
+          });
+        }
+      : () => {
+          setIsVisible(window.scrollY > window.innerHeight - 14);
+        };
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    window.addEventListener('resize', handleScroll, { passive: true });
 
     // Set initial visibility based on current scroll position
     handleScroll();
 
     return () => {
+      if (frame) cancelAnimationFrame(frame);
       window.removeEventListener('scroll', handleScroll);
+      window.removeEventListener('resize', handleScroll);
     };
   }, []);
 

--- a/frontend/src/components/Pages/About/About.tsx
+++ b/frontend/src/components/Pages/About/About.tsx
@@ -23,14 +23,16 @@ import Typescript from '../../../assets/icons/Typescript';
 import Go from '../../../assets/icons/Go';
 import TechIcon from '../Skills/TechIcon';
 import { bioParagraphs, whatDrivesMe, outsideOfWork, continuousLearning } from './aboutData';
+import { useScrollReveal } from '../../../hooks/useScrollReveal';
 
 const About = () => {
   const theme = useTheme();
+  const reveal = useScrollReveal();
   // Shared by every sub-panel below so the section reads as a set of
   // layered cards (the hero's idiom) rather than one continuous text
   // column -- matches Skills' skillCardSx: same border/bg treatment, no
-  // translucent overlays sitting behind body text (that's produced wrong
-  // contrast readings twice on this project per the sprint brief).
+  // translucent overlays sitting behind body text, which has produced wrong
+  // contrast readings twice on this project.
   const panelSx = {
     height: '100%',
     backgroundColor: theme.palette.background.default,
@@ -38,7 +40,7 @@ const About = () => {
   };
 
   return (
-    <Stack id="about" component={'section'}>
+    <Stack id="about" component={'section'} ref={reveal.ref} sx={reveal.sx}>
       <Card
         sx={{
           // `overflow: visible` is load-bearing, not cosmetic. MUI's Card sets

--- a/frontend/src/components/Pages/Contact/Contact.tsx
+++ b/frontend/src/components/Pages/Contact/Contact.tsx
@@ -15,8 +15,10 @@ import {
 } from '@mui/material';
 import ContactForm from '../../ConnectForm/ConnectForm';
 import LinkIcon from '@mui/icons-material/Link';
+import { useScrollReveal } from '../../../hooks/useScrollReveal';
 
 const Contact = () => {
+  const reveal = useScrollReveal();
   const theme = useTheme();
   const largeMobile = useMediaQuery(theme.breakpoints.down(425));
   const tablet = useMediaQuery(theme.breakpoints.down(650));
@@ -95,7 +97,7 @@ const Contact = () => {
   );
 
   return (
-    <Stack id="contact" component={'section'} sx={{ height: 'auto' }}>
+    <Stack id="contact" component={'section'} ref={reveal.ref} sx={[{ height: 'auto' }, reveal.sx]}>
       <Card
         sx={{
           // `overflow: visible` is load-bearing, not cosmetic. MUI's Card sets

--- a/frontend/src/components/Pages/Experience/Experience.tsx
+++ b/frontend/src/components/Pages/Experience/Experience.tsx
@@ -11,12 +11,19 @@ import {
 import { alpha } from '@mui/material/styles';
 import LinkIcon from '@mui/icons-material/Link';
 import { experienceData } from './experienceData';
+import { useScrollReveal } from '../../../hooks/useScrollReveal';
 
 const Experience = () => {
+  const reveal = useScrollReveal();
   const theme = useTheme();
 
   return (
-    <Stack id="experience" component={'section'} sx={{ height: 'auto', width: '100%' }}>
+    <Stack
+      id="experience"
+      component={'section'}
+      ref={reveal.ref}
+      sx={[{ height: 'auto', width: '100%' }, reveal.sx]}
+    >
       <Card
         sx={{
           // `overflow: visible` is load-bearing, not cosmetic. MUI's Card sets

--- a/frontend/src/components/Pages/Home/Home.tsx
+++ b/frontend/src/components/Pages/Home/Home.tsx
@@ -13,8 +13,10 @@ const Home = () => {
         width: '100%',
         // Defence in depth, not the primary fix. The root cause of sections
         // clipping and running into each other was `section { height: ... }`
-        // in global.css pinning every section to one viewport; that is now a
-        // min-height. This keeps a section from being squeezed below its own
+        // in global.css pinning every section to one viewport; that rule is
+        // now gone entirely (min-height stopped the spill but kept the stretch,
+        // which is what left the dead space under Skills and Contact). This
+        // keeps a section from being squeezed below its own
         // content should it ever exceed that minimum -- a flex item only keeps
         // its automatic minimum size while `overflow` is `visible`, and the
         // section Cards are deliberately `overflow: visible`.

--- a/frontend/src/components/Pages/Landing/Landing.tsx
+++ b/frontend/src/components/Pages/Landing/Landing.tsx
@@ -445,11 +445,8 @@ const Landing = () => {
           </Box>
         </Box>
 
-        {/* Scroll Indicator. The attribute is load-bearing, not a test hook:
-            `useShowNavBar` observes this element so the global NavBar appears
-            the instant the arrow leaves the viewport. */}
+        {/* Scroll Indicator */}
         <Stack
-          {...{ [SCROLL_INDICATOR_ATTR]: true }}
           sx={{
             pb: 3,
             display: 'flex',
@@ -457,7 +454,19 @@ const Landing = () => {
             gap: 1.5,
           }}
         >
+          {/* The attribute is load-bearing, not a test hook: `useShowNavBar`
+              measures this element so the global NavBar appears as the arrow
+              leaves the viewport.
+
+              It sits here rather than on the Stack, which adds 24px of bottom
+              padding and so stays on screen well after the arrow has visibly
+              gone; and rather than on the arrow glyph itself, which is the
+              tightest box but is running the `bounce` animation -- a 6px
+              oscillation would drag the measured edge back and forth across
+              the threshold and flicker the bar. This button is the tightest
+              box that holds still. */}
           <IconButton
+            {...{ [SCROLL_INDICATOR_ATTR]: true }}
             size={'large'}
             onClick={() => nextSection && scrollToSection(nextSection.id)}
             aria-label={

--- a/frontend/src/components/Pages/Landing/Landing.tsx
+++ b/frontend/src/components/Pages/Landing/Landing.tsx
@@ -10,6 +10,7 @@ import LinkedIn from '@mui/icons-material/LinkedIn';
 import Mail from '@mui/icons-material/Mail';
 import Menu from '@mui/icons-material/Menu';
 import { navLinks } from '../../AppShell/InternalComponents/navLinks';
+import { SCROLL_INDICATOR_ATTR } from '../../AppShell/InternalComponents/useShowNavBar';
 import { useAppShellLayout } from '../../AppShell/AppShellLayoutContext';
 
 const Landing = () => {
@@ -444,8 +445,11 @@ const Landing = () => {
           </Box>
         </Box>
 
-        {/* Scroll Indicator */}
+        {/* Scroll Indicator. The attribute is load-bearing, not a test hook:
+            `useShowNavBar` observes this element so the global NavBar appears
+            the instant the arrow leaves the viewport. */}
         <Stack
+          {...{ [SCROLL_INDICATOR_ATTR]: true }}
           sx={{
             pb: 3,
             display: 'flex',

--- a/frontend/src/components/Pages/Projects/Projects.tsx
+++ b/frontend/src/components/Pages/Projects/Projects.tsx
@@ -18,6 +18,7 @@ import CodeIcon from '@mui/icons-material/Code';
 import StarIcon from '@mui/icons-material/StarBorder';
 import { staticProjects, type StaticProject } from './staticProjects';
 import useProjects, { type ApiProject } from './useProjects';
+import { useScrollReveal } from '../../../hooks/useScrollReveal';
 
 /**
  * A static project entry merged with live metadata (F1). The static entry
@@ -50,6 +51,11 @@ const formatUpdatedAt = (iso: string): string | null => {
  * @see https://mui-treasury.com/?path=/story/card-solidgame--solid-game
  */
 const Projects = () => {
+  const reveal = useScrollReveal();
+  // The cards cascade instead of arriving as one slab. Note this stays
+  // revealed once triggered, so the skeleton -> loaded-card swap does not
+  // re-run the animation -- that swap should be instant, not staged.
+  const cards = useScrollReveal({ stagger: 80, distance: 18 });
   const theme = useTheme();
   const largeMobile = useMediaQuery(theme.breakpoints.down(600));
   const { apiProjects, isLoading } = useProjects();
@@ -57,7 +63,7 @@ const Projects = () => {
   const displayProjects = staticProjects.map((project) => mergeProject(project, apiProjects));
 
   return (
-    <Stack id="projects" component={'section'}>
+    <Stack id="projects" component={'section'} ref={reveal.ref} sx={reveal.sx}>
       <Card
         sx={{
           // `overflow: visible` is load-bearing, not cosmetic. MUI's Card sets
@@ -112,11 +118,15 @@ const Projects = () => {
           <Grid
             container
             spacing={2}
-            sx={{
-              width: '100%',
-              height: '100%',
-              justifyContent: 'center',
-            }}
+            ref={cards.ref}
+            sx={[
+              {
+                width: '100%',
+                height: '100%',
+                justifyContent: 'center',
+              },
+              cards.sx,
+            ]}
           >
             {isLoading
               ? staticProjects.map((project) => (

--- a/frontend/src/components/Pages/Skills/Skills.tsx
+++ b/frontend/src/components/Pages/Skills/Skills.tsx
@@ -13,8 +13,12 @@ import {
 import LinkIcon from '@mui/icons-material/Link';
 import { skillCategories, type SkillItem } from './skillsData';
 import TechIcon from './TechIcon';
+import { useScrollReveal } from '../../../hooks/useScrollReveal';
 
 const Skills = () => {
+  const reveal = useScrollReveal();
+  // The three category cards cascade rather than appearing as one block.
+  const cards = useScrollReveal({ stagger: 90, distance: 18 });
   const theme = useTheme();
   // Sprint 14 (I3): was a hardcoded `rgb(18, 72, 116)` -- a fixed blue that
   // read wrong against five of the six themes (only dark/blue are blue at
@@ -38,7 +42,7 @@ const Skills = () => {
   const skillChipsSx = { display: 'flex', flexWrap: 'wrap', gap: 1 };
 
   return (
-    <Stack id="skills" component={'section'}>
+    <Stack id="skills" component={'section'} ref={reveal.ref} sx={reveal.sx}>
       <Card
         sx={{
           // `overflow: visible` is load-bearing, not cosmetic. MUI's Card sets
@@ -91,7 +95,7 @@ const Skills = () => {
               width -- a 2-up grid (1-up below `sm`) gives each card room for
               its chips to wrap instead of being squeezed to min-content,
               which is what broke at 320-390px before Sprint 9's fix. */}
-          <Grid container spacing={3}>
+          <Grid container spacing={3} ref={cards.ref} sx={cards.sx}>
             {skillCategories.map((category) => (
               <Grid key={category.label} size={{ xs: 12, sm: 6 }}>
                 <Card sx={skillCardSx}>

--- a/frontend/src/hooks/useScrollReveal.test.tsx
+++ b/frontend/src/hooks/useScrollReveal.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { useScrollReveal, type ScrollRevealOptions } from './useScrollReveal';
+
+/**
+ * The property that actually matters here is the failure mode: a reveal
+ * animation that fails closed hides the entire page. Most of these check that
+ * content ends up visible in every environment where the animation cannot run.
+ *
+ * These render a real element rather than using `renderHook`, because the hook
+ * only arms itself once its ref is attached to something -- a bare `renderHook`
+ * leaves `ref.current` null, which is (correctly) treated as "cannot animate,
+ * so show the content".
+ */
+
+type IOCallback = (entries: IntersectionObserverEntry[]) => void;
+
+const installObserver = () => {
+  const instances: { callback: IOCallback; disconnect: ReturnType<typeof vi.fn> }[] = [];
+  class MockIO {
+    callback: IOCallback;
+    disconnect = vi.fn();
+    observe = vi.fn();
+    constructor(callback: IOCallback) {
+      this.callback = callback;
+      instances.push(this);
+    }
+  }
+  vi.stubGlobal('IntersectionObserver', MockIO);
+  return instances;
+};
+
+/** Mirrors real usage: the hook's ref and sx go onto one element. */
+const seen: { sx: Record<string, unknown>; revealed: boolean } = { sx: {}, revealed: false };
+const Probe = (options: ScrollRevealOptions) => {
+  const { ref, sx, revealed } = useScrollReveal<HTMLDivElement>(options);
+  seen.sx = sx as Record<string, unknown>;
+  seen.revealed = revealed;
+  return <div ref={ref} data-testid="probe" />;
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('useScrollReveal', () => {
+  it('starts revealed when there is no IntersectionObserver, rather than hiding the content', () => {
+    // jsdom ships none, as does any browser old enough to lack it. Failing
+    // closed here would blank the page instead of skipping an animation.
+    render(<Probe />);
+
+    expect(seen.revealed).toBe(true);
+    expect(seen.sx).toEqual({});
+  });
+
+  it('starts hidden and offset when it can animate', () => {
+    installObserver();
+    render(<Probe />);
+
+    expect(seen.revealed).toBe(false);
+    expect(seen.sx).toMatchObject({ opacity: 0 });
+  });
+
+  it('reveals when the element intersects, and stops observing so it cannot replay', () => {
+    const instances = installObserver();
+    render(<Probe />);
+
+    act(() => {
+      instances[0].callback([{ isIntersecting: true } as IntersectionObserverEntry]);
+    });
+
+    expect(seen.revealed).toBe(true);
+    expect(seen.sx).toMatchObject({ opacity: 1, transform: 'none' });
+    // Re-animating every time you scroll past is this effect's tacky mode.
+    expect(instances[0].disconnect).toHaveBeenCalled();
+  });
+
+  it('stays hidden while the element has not yet been reached', () => {
+    const instances = installObserver();
+    render(<Probe />);
+
+    act(() => {
+      instances[0].callback([{ isIntersecting: false } as IntersectionObserverEntry]);
+    });
+
+    expect(seen.revealed).toBe(false);
+  });
+
+  it('applies no animation at all under prefers-reduced-motion', () => {
+    installObserver();
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn((query: string) => ({
+        matches: query.includes('prefers-reduced-motion'),
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        onchange: null,
+        dispatchEvent: vi.fn(),
+      })),
+    );
+
+    render(<Probe />);
+
+    expect(seen.revealed).toBe(true);
+    expect(seen.sx).toEqual({});
+  });
+
+  it('staggers direct children by the given interval instead of moving the container', () => {
+    installObserver();
+    render(<Probe stagger={80} />);
+    const sx = seen.sx as Record<string, { transitionDelay?: string }>;
+
+    expect(sx['& > *:nth-of-type(1)'].transitionDelay).toBe('0ms');
+    expect(sx['& > *:nth-of-type(2)'].transitionDelay).toBe('80ms');
+    expect(sx['& > *:nth-of-type(3)'].transitionDelay).toBe('160ms');
+    // The container itself must not move -- it owns the grid layout.
+    expect(sx.opacity).toBeUndefined();
+    expect(sx.transform).toBeUndefined();
+  });
+
+  it('caps the stagger so a long list does not trail further and further behind', () => {
+    installObserver();
+    render(<Probe stagger={100} staggerCap={3} />);
+    const sx = seen.sx as Record<string, { transitionDelay?: string }>;
+
+    expect(sx['& > *:nth-of-type(3)'].transitionDelay).toBe('200ms');
+    expect(sx['& > *:nth-of-type(n + 4)'].transitionDelay).toBe('200ms');
+  });
+});

--- a/frontend/src/hooks/useScrollReveal.test.tsx
+++ b/frontend/src/hooks/useScrollReveal.test.tsx
@@ -61,7 +61,7 @@ describe('useScrollReveal', () => {
     expect(seen.sx).toMatchObject({ opacity: 0 });
   });
 
-  it('reveals when the element intersects, and stops observing so it cannot replay', () => {
+  it('reveals when the element intersects', () => {
     const instances = installObserver();
     render(<Probe />);
 
@@ -71,8 +71,47 @@ describe('useScrollReveal', () => {
 
     expect(seen.revealed).toBe(true);
     expect(seen.sx).toMatchObject({ opacity: 1, transform: 'none' });
-    // Re-animating every time you scroll past is this effect's tacky mode.
-    expect(instances[0].disconnect).toHaveBeenCalled();
+  });
+
+  it('fades back out when the element leaves again, so the effect is reversible', () => {
+    const instances = installObserver();
+    render(<Probe />);
+
+    act(() => {
+      instances[0].callback([{ isIntersecting: true } as IntersectionObserverEntry]);
+    });
+    expect(seen.revealed).toBe(true);
+
+    // Scrolling back up: it must not latch on the first reveal.
+    act(() => {
+      instances[0].callback([{ isIntersecting: false } as IntersectionObserverEntry]);
+    });
+
+    expect(seen.revealed).toBe(false);
+    expect(seen.sx).toMatchObject({ opacity: 0 });
+    expect(instances[0].disconnect).not.toHaveBeenCalled();
+  });
+
+  it('drops the stagger delay on the way out', () => {
+    // A reverse cascade on exit reads as the page unloading rather than
+    // animating, so delays are for the entrance only.
+    const instances = installObserver();
+    render(<Probe stagger={80} />);
+
+    act(() => {
+      instances[0].callback([{ isIntersecting: true } as IntersectionObserverEntry]);
+    });
+    expect(
+      (seen.sx as Record<string, { transitionDelay?: string }>)['& > *:nth-of-type(2)'],
+    ).toBeDefined();
+
+    act(() => {
+      instances[0].callback([{ isIntersecting: false } as IntersectionObserverEntry]);
+    });
+
+    const sx = seen.sx as Record<string, { transitionDelay?: string }>;
+    expect(sx['& > *:nth-of-type(2)']).toBeUndefined();
+    expect(sx['& > *'].transitionDelay).toBe('0ms');
   });
 
   it('stays hidden while the element has not yet been reached', () => {
@@ -109,8 +148,11 @@ describe('useScrollReveal', () => {
   });
 
   it('staggers direct children by the given interval instead of moving the container', () => {
-    installObserver();
+    const instances = installObserver();
     render(<Probe stagger={80} />);
+    act(() => {
+      instances[0].callback([{ isIntersecting: true } as IntersectionObserverEntry]);
+    });
     const sx = seen.sx as Record<string, { transitionDelay?: string }>;
 
     expect(sx['& > *:nth-of-type(1)'].transitionDelay).toBe('0ms');
@@ -122,8 +164,11 @@ describe('useScrollReveal', () => {
   });
 
   it('caps the stagger so a long list does not trail further and further behind', () => {
-    installObserver();
+    const instances = installObserver();
     render(<Probe stagger={100} staggerCap={3} />);
+    act(() => {
+      instances[0].callback([{ isIntersecting: true } as IntersectionObserverEntry]);
+    });
     const sx = seen.sx as Record<string, { transitionDelay?: string }>;
 
     expect(sx['& > *:nth-of-type(3)'].transitionDelay).toBe('200ms');

--- a/frontend/src/hooks/useScrollReveal.ts
+++ b/frontend/src/hooks/useScrollReveal.ts
@@ -28,19 +28,28 @@ const EASING = 'cubic-bezier(0.22, 0.61, 0.36, 1)';
 const DURATION_MS = 600;
 
 /**
- * Reveals an element as it scrolls into view: a short upward drift plus a fade,
- * once, and never again.
+ * How far into the viewport an element has to travel before it starts, as a
+ * percentage of the window height. A wheel notch is ~100px, so on a typical
+ * ~900px window this is a scroll and a half of lead-in rather than firing the
+ * instant the element's top edge appears.
+ */
+const REVEAL_INSET_PERCENT = 25;
+
+/**
+ * Reveals an element as it scrolls into view -- a short upward drift plus a
+ * fade -- and fades it back out when it leaves.
  *
- * Three things this deliberately does *not* do, each of which is a bug this
+ * Three properties worth keeping, the first and last of which are bugs this
  * project has already shipped once in another form:
  *
  * 1. **It never leaves content permanently invisible.** If the element can't be
  *    animated -- `prefers-reduced-motion`, or no `IntersectionObserver` (jsdom,
  *    older browsers) -- it starts revealed and no opacity is ever applied. An
  *    animation that fails closed would hide the whole page.
- * 2. **It doesn't re-animate on scroll-back.** The observer disconnects on the
- *    first reveal. Content that re-fades every time you scroll past is the
- *    "super extra" version of this effect.
+ * 2. **It is reversible.** Scrolling back up fades the element out again, so
+ *    the effect reads the same in both directions rather than being a one-way
+ *    door. The fade-out drops any stagger delay -- a reverse cascade on the way
+ *    out looks like the page is unloading, not like it is animating.
  * 3. **It only ever touches `opacity` and `transform`,** so it cannot move
  *    layout and cannot contribute to CLS -- which is what dragged this site's
  *    performance score from 96 to 75 once already (see Sprint 8). The revealed
@@ -74,19 +83,23 @@ export const useScrollReveal = <T extends HTMLElement = HTMLDivElement>(
 
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) {
-          setRevealed(true);
-          observer.disconnect();
-        }
+        const entry = entries[entries.length - 1];
+        // Reversible: it fades back out on the way up, so this tracks the
+        // observer rather than latching on the first reveal.
+        if (entry) setRevealed(entry.isIntersecting);
       },
       {
-        // threshold 0 + a fixed bottom inset, rather than a ratio. A ratio
-        // looks tidier but cannot be satisfied by an element taller than
+        // threshold 0 + a bottom inset, rather than a ratio. A ratio looks
+        // tidier but cannot be satisfied by an element taller than
         // `viewport / ratio`, so a long section would never reveal at all. The
-        // inset only requires the element's top edge to clear a line 64px
-        // above the viewport bottom, which any section or footer can do.
+        // inset only asks the element's top edge to clear a line partway up
+        // the viewport, which any section or footer can do at any height.
+        //
+        // 25% rather than a pixel count so the wait scales with the window:
+        // the element has to come about a scroll and a half past the bottom
+        // edge before it starts, instead of firing the moment it peeks in.
         threshold: 0,
-        rootMargin: '0px 0px -64px 0px',
+        rootMargin: `0px 0px -${REVEAL_INSET_PERCENT}% 0px`,
       },
     );
 
@@ -116,26 +129,39 @@ export const useScrollReveal = <T extends HTMLElement = HTMLDivElement>(
             opacity: 0,
             transform: hiddenTransform,
             transition,
-            transitionDelay: `${delay}ms`,
+            // No delay on the way out. A delayed fade-out leaves the element
+            // sitting there after it should already be going.
+            transitionDelay: '0ms',
             willChange: 'opacity, transform',
           };
     }
 
     // Stagger mode: the container itself stays untouched and its children carry
     // the effect, so the container's own layout role (grid, flex) is unchanged.
+    // Delays apply on the way in only -- see above.
     const childDelays: Record<string, { transitionDelay: string }> = {};
-    for (let i = 0; i < staggerCap; i++) {
-      childDelays[`& > *:nth-of-type(${i + 1})`] = { transitionDelay: `${delay + i * stagger}ms` };
+    if (revealed) {
+      for (let i = 0; i < staggerCap; i++) {
+        childDelays[`& > *:nth-of-type(${i + 1})`] = {
+          transitionDelay: `${delay + i * stagger}ms`,
+        };
+      }
+      // Everything past the cap lands with the last staggered child.
+      childDelays[`& > *:nth-of-type(n + ${staggerCap + 1})`] = {
+        transitionDelay: `${delay + (staggerCap - 1) * stagger}ms`,
+      };
     }
-    // Everything past the cap lands with the last staggered child.
-    childDelays[`& > *:nth-of-type(n + ${staggerCap + 1})`] = {
-      transitionDelay: `${delay + (staggerCap - 1) * stagger}ms`,
-    };
 
     return {
       '& > *': revealed
         ? { opacity: 1, transform: 'none', transition }
-        : { opacity: 0, transform: hiddenTransform, transition, willChange: 'opacity, transform' },
+        : {
+            opacity: 0,
+            transform: hiddenTransform,
+            transition,
+            transitionDelay: '0ms',
+            willChange: 'opacity, transform',
+          },
       ...childDelays,
     };
   }, [canAnimate, revealed, delay, distance, stagger, staggerCap]);

--- a/frontend/src/hooks/useScrollReveal.ts
+++ b/frontend/src/hooks/useScrollReveal.ts
@@ -1,5 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import useMediaQuery from '@mui/material/useMediaQuery';
+// From the barrel, like every other MUI import in this codebase. The deep path
+// (`@mui/material/useMediaQuery`) is a separate entry for Vite's dependency
+// pre-bundling, and adding it mid-session made the dev server re-optimize and
+// serve a module graph with two copies of React in it -- `useMediaQuery` then
+// read `useContext` off a null React internals object and took the page down.
+import { useMediaQuery } from '@mui/material';
 
 export interface ScrollRevealOptions {
   /** ms to wait after the element enters before it starts moving. Use to offset

--- a/frontend/src/hooks/useScrollReveal.ts
+++ b/frontend/src/hooks/useScrollReveal.ts
@@ -1,0 +1,139 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import useMediaQuery from '@mui/material/useMediaQuery';
+
+export interface ScrollRevealOptions {
+  /** ms to wait after the element enters before it starts moving. Use to offset
+   * a section against its own heading, not to sequence whole sections -- the
+   * viewport already sequences those. */
+  delay?: number;
+  /** px the element travels upward as it fades in. Deliberately small: this is
+   * meant to read as "settling into place", not as an entrance. */
+  distance?: number;
+  /** When set, the element's *direct children* animate instead of the element
+   * itself, each one `stagger` ms behind the last. For card grids, where one
+   * block fading in reads flat but a quick cascade reads deliberate. */
+  stagger?: number;
+  /** How many children to generate stagger delays for. Anything beyond this
+   * shares the last delay rather than trailing further and further behind. */
+  staggerCap?: number;
+}
+
+/** Matches the hero's existing easing character: quick to leave, gentle to land. */
+const EASING = 'cubic-bezier(0.22, 0.61, 0.36, 1)';
+const DURATION_MS = 600;
+
+/**
+ * Reveals an element as it scrolls into view: a short upward drift plus a fade,
+ * once, and never again.
+ *
+ * Three things this deliberately does *not* do, each of which is a bug this
+ * project has already shipped once in another form:
+ *
+ * 1. **It never leaves content permanently invisible.** If the element can't be
+ *    animated -- `prefers-reduced-motion`, or no `IntersectionObserver` (jsdom,
+ *    older browsers) -- it starts revealed and no opacity is ever applied. An
+ *    animation that fails closed would hide the whole page.
+ * 2. **It doesn't re-animate on scroll-back.** The observer disconnects on the
+ *    first reveal. Content that re-fades every time you scroll past is the
+ *    "super extra" version of this effect.
+ * 3. **It only ever touches `opacity` and `transform`,** so it cannot move
+ *    layout and cannot contribute to CLS -- which is what dragged this site's
+ *    performance score from 96 to 75 once already (see Sprint 8). The revealed
+ *    state resets `transform` to `none` rather than `translateY(0)` so the
+ *    finished element stops being a containing block.
+ *
+ * @returns a `ref` for the element and an `sx` fragment to spread into its own.
+ */
+export const useScrollReveal = <T extends HTMLElement = HTMLDivElement>(
+  options: ScrollRevealOptions = {},
+) => {
+  const { delay = 0, distance = 24, stagger, staggerCap = 8 } = options;
+  const prefersReducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
+  const ref = useRef<T | null>(null);
+
+  const canAnimate =
+    !prefersReducedMotion && typeof window !== 'undefined' && 'IntersectionObserver' in window;
+
+  const [revealed, setRevealed] = useState(!canAnimate);
+
+  useEffect(() => {
+    if (!canAnimate) {
+      setRevealed(true);
+      return;
+    }
+    const element = ref.current;
+    if (!element) {
+      setRevealed(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setRevealed(true);
+          observer.disconnect();
+        }
+      },
+      {
+        // threshold 0 + a fixed bottom inset, rather than a ratio. A ratio
+        // looks tidier but cannot be satisfied by an element taller than
+        // `viewport / ratio`, so a long section would never reveal at all. The
+        // inset only requires the element's top edge to clear a line 64px
+        // above the viewport bottom, which any section or footer can do.
+        threshold: 0,
+        rootMargin: '0px 0px -64px 0px',
+      },
+    );
+
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [canAnimate]);
+
+  // Deliberately left to inference rather than annotated `SxProps<Theme>`.
+  // `SxProps` is itself allowed to be an array, so a value typed that way
+  // cannot be used as an *element* of MUI's array-form `sx` -- which is exactly
+  // how callers with their own styles need to combine it.
+  const sx = useMemo(() => {
+    if (!canAnimate) return {};
+
+    const transition = `opacity ${DURATION_MS}ms ${EASING}, transform ${DURATION_MS}ms ${EASING}`;
+    // Phones get a shorter travel: the same 24px reads as a lurch on a small
+    // viewport where the element occupies most of the screen.
+    const hiddenTransform = {
+      xs: `translateY(${Math.round(distance * 0.6)}px)`,
+      sm: `translateY(${distance}px)`,
+    };
+
+    if (stagger === undefined) {
+      return revealed
+        ? { opacity: 1, transform: 'none', transition, transitionDelay: `${delay}ms` }
+        : {
+            opacity: 0,
+            transform: hiddenTransform,
+            transition,
+            transitionDelay: `${delay}ms`,
+            willChange: 'opacity, transform',
+          };
+    }
+
+    // Stagger mode: the container itself stays untouched and its children carry
+    // the effect, so the container's own layout role (grid, flex) is unchanged.
+    const childDelays: Record<string, { transitionDelay: string }> = {};
+    for (let i = 0; i < staggerCap; i++) {
+      childDelays[`& > *:nth-of-type(${i + 1})`] = { transitionDelay: `${delay + i * stagger}ms` };
+    }
+    // Everything past the cap lands with the last staggered child.
+    childDelays[`& > *:nth-of-type(n + ${staggerCap + 1})`] = {
+      transitionDelay: `${delay + (staggerCap - 1) * stagger}ms`,
+    };
+
+    return {
+      '& > *': revealed
+        ? { opacity: 1, transform: 'none', transition }
+        : { opacity: 0, transform: hiddenTransform, transition, willChange: 'opacity, transform' },
+      ...childDelays,
+    };
+  }, [canAnimate, revealed, delay, distance, stagger, staggerCap]);
+
+  return { ref, sx, revealed };
+};


### PR DESCRIPTION
## What

Scroll-reveal animations for every section, plus a fix for the nav bar showing up late coming off the hero.

### The nav bar

The rule was `scrollY > innerHeight - 14`, which measures the **window** rather than the arrow, so its error moved with the window height — 30px early on a 900px window, 219px early on a 650px one. It read as *late* rather than early because the bar then took a 1000ms `Fade` to arrive. Now the hero's arrow tags itself and `useShowNavBar` reads that element's own position: 0px error at every height from 650 to 1200, with a 220ms in / 160ms out transition.

The attribute sits on the arrow's `IconButton` — not the padded `Stack` (24px of padding kept it on screen ~38px too long, which was the reported symptom) and not the glyph itself (its `bounce` animation would oscillate the measured edge and flicker the bar).

### The reveals

`useScrollReveal` fades each section up 24px as it arrives (600ms), starting once its top edge is 25% of the way up the window — about two wheel notches of lead-in. Reversible: scrolling back up fades sections out again. Skills and Projects cascade their cards 90ms/80ms apart.

Three constraints shaped it:

- **It cannot fail closed.** Without `IntersectionObserver` or under `prefers-reduced-motion`, sections start revealed with no opacity applied. An animation that fails closed blanks the page.
- **Only `opacity` and `transform`**, so it cannot move layout or add CLS.
- **No DOM structure changed** — the hook returns a ref and an sx fragment onto the existing elements, leaving the flex/overflow rules alone.

### Also

`useScrollReveal` originally imported `@mui/material/useMediaQuery` by its deep path. That is a separate entry for Vite's dependency pre-bundling, so it made a running dev server re-optimize mid-session and serve a module graph with two copies of React — the page died through the error boundary. Now imported from the barrel like every other MUI import here. Note the e2e suite runs against `vite preview`, where Rollup dedupes, so it could never have caught this.

## Verification

- 93 unit tests (15 new across both hooks), 9 e2e (3 new), lint and `tsc --noEmit` clean
- Browser-checked at 320/390/1280/1918 wide and 650–1200 tall, all three layout modes, plus reduced motion
- Nav timing measured at 0px error across five window heights; correct at load, after a deep reload, and on anchor navigation
- Reveal verified with real wheel input, not scroll jumps: opacity ramps 30 → 72 → 91 → 98 → 100 with no flicker at the trigger line
- Max-scroll case checked and pinned in e2e, since a later trigger could otherwise strand the last section permanently hidden
- The new nav tests were negative-controlled: reverting the hook to the old rule makes them fail