### PR TITLE
Projects: shrink the cards, equalise heights, fix the hover per theme

### DIFF
--- a/frontend/src/components/Pages/Projects/Projects.tsx
+++ b/frontend/src/components/Pages/Projects/Projects.tsx
@@ -16,9 +16,44 @@ import {
 import LinkIcon from '@mui/icons-material/Link';
 import CodeIcon from '@mui/icons-material/Code';
 import StarIcon from '@mui/icons-material/StarBorder';
+import { type Theme } from '@mui/material/styles';
 import { staticProjects, type StaticProject } from './staticProjects';
 import useProjects, { type ApiProject } from './useProjects';
 import { useScrollReveal } from '../../../hooks/useScrollReveal';
+
+/**
+ * One column split, shared by the real card and its skeleton so the two can
+ * never drift and cause the swap to jump. Four across on a wide screen, which
+ * is what the current project count fills exactly -- at `md: 4` the fourth card
+ * wrapped onto a row of its own and sat there centred, looking like a mistake.
+ */
+const PROJECT_GRID_SIZE = { xs: 12, sm: 6, md: 4, lg: 3 };
+
+/**
+ * Caps how wide the grid may get. On a 1918px window the cards were 602px wide
+ * with a 339px image -- one project taking up most of the screen. The section
+ * card itself still spans the full width; only the grid inside it is bounded.
+ */
+const PROJECT_GRID_MAX_WIDTH = 1200;
+
+/**
+ * The card shell, shared with the skeleton. The border is doing real work
+ * rather than decoration: in the light theme the card background (#f4f5f7) sat
+ * on the section's white paper with almost no edge, so the cards read as
+ * screenshots floating on the page instead of as cards.
+ */
+const projectCardSx = {
+  width: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+  bgcolor: 'background.default',
+  border: '1px solid',
+  borderColor: 'divider',
+  // Kept visible, like the section cards: MUI's Card default of `hidden`
+  // combined with a flex parent is what silently clipped content elsewhere on
+  // this page. Nothing here needs clipping.
+  overflow: 'visible',
+};
 
 /**
  * A static project entry merged with live metadata (F1). The static entry
@@ -52,9 +87,7 @@ const formatUpdatedAt = (iso: string): string | null => {
  */
 const Projects = () => {
   const reveal = useScrollReveal();
-  // The cards cascade instead of arriving as one slab. Note this stays
-  // revealed once triggered, so the skeleton -> loaded-card swap does not
-  // re-run the animation -- that swap should be instant, not staged.
+  // The cards cascade in instead of arriving as one slab.
   const cards = useScrollReveal({ stagger: 80, distance: 18 });
   const theme = useTheme();
   const largeMobile = useMediaQuery(theme.breakpoints.down(600));
@@ -110,7 +143,10 @@ const Projects = () => {
             width: '100%',
             height: '100%',
             display: 'flex',
-            justifyContent: 'center',
+            // The grid is width-capped, so this positions the capped box itself
+            // -- centring it here is what pushed the cards away from the
+            // section's left-aligned heading.
+            justifyContent: 'flex-start',
             alignItems: 'center',
             flexGrow: 1,
           }}
@@ -122,8 +158,15 @@ const Projects = () => {
             sx={[
               {
                 width: '100%',
-                height: '100%',
-                justifyContent: 'center',
+                maxWidth: PROJECT_GRID_MAX_WIDTH,
+                // Left-aligned rather than centred: the section's "Projects"
+                // heading sits at the left edge, and a centred grid inside a
+                // full-width section card left a wide gutter that made the
+                // cards look detached from their own heading.
+                justifyContent: 'flex-start',
+                // Every card in a row gets the row's height; see the Grid item
+                // in ProjectCard for why this matters.
+                alignItems: 'stretch',
               },
               cards.sx,
             ]}
@@ -154,35 +197,60 @@ const ProjectCard = ({
   return (
     <Grid
       data-testid="project-grid-item"
-      sx={{
-        justifyContent: 'center',
-      }}
-      size={{
-        xs: 12,
-        sm: 6,
-        md: 4,
-        lg: 4,
-        xl: 4,
-      }}
+      // `display: flex` is what lets the Card below stretch to the height of
+      // the tallest card in its row. Without it each card sized to its own
+      // content and the row bottoms came out ragged -- 20px apart on desktop
+      // and 72px on mobile, where a two-line description on one card and a
+      // one-line on the next is the whole difference.
+      sx={{ display: 'flex' }}
+      size={PROJECT_GRID_SIZE}
     >
-      {/* No fixed/percentage height anywhere in this card -- `height: 300` plus
-          a `height: '50%'` image and a `maxHeight: '60%'` CardContent looked
-          like a deliberate 50/60 split, but percentages don't clip cleanly:
-          at every width the description text needed more than the 60% cap
-          allowed, and Card's default `overflow: hidden` swallowed the rest
-          silently. Sizing every piece from its own content (image at a fixed
-          aspect ratio, text unconstrained) means the card is exactly as tall
-          as it needs to be, matching how the section-level cards were fixed. */}
-      <Card sx={{ width: '100%', bgcolor: 'background.default', overflow: 'visible' }}>
+      {/* Still no fixed height on the card -- `height: 300` plus a `height:
+          '50%'` image and a `maxHeight: '60%'` CardContent once looked like a
+          deliberate 50/60 split, but percentages don't clip cleanly and Card's
+          default `overflow: hidden` swallowed the excess silently. Cards match
+          each other by stretching within the row, not by being told a height. */}
+      <Card
+        sx={{
+          ...projectCardSx,
+          transition: (theme: Theme) =>
+            theme.transitions.create(['transform', 'box-shadow', 'border-color'], {
+              duration: theme.transitions.duration.shorter,
+            }),
+          '&:hover': {
+            // Border + lift + shadow rather than MUI's default wash, which is a
+            // flat tint of `text.primary` and reads completely differently per
+            // theme: 4% black on the light theme's near-white card was all but
+            // invisible, against 8% white on dark. Primary is defined per theme
+            // and is guaranteed to contrast with the surface, so the same rule
+            // works in all six.
+            borderColor: 'primary.main',
+            boxShadow: 6,
+            transform: 'translateY(-4px)',
+          },
+          '@media (prefers-reduced-motion: reduce)': {
+            transition: 'none',
+            '&:hover': { transform: 'none' },
+          },
+        }}
+      >
         <CardActionArea
           href={project.href}
           target="_blank"
           sx={{
             width: '100%',
+            // Fills the stretched card so the whole surface stays clickable,
+            // and lets the content column push its metadata row to the bottom.
+            flexGrow: 1,
             display: 'flex',
             flexDirection: 'column',
             justifyContent: 'flex-start',
-            alignItems: 'center',
+            alignItems: 'stretch',
+            // MUI's own hover overlay, neutralised in favour of the card rule
+            // above. The focus-visible ring is untouched -- it comes from the
+            // shared MuiButtonBase override, not from this highlight.
+            '& .MuiCardActionArea-focusHighlight': { opacity: 0 },
+            '&:hover .MuiCardActionArea-focusHighlight': { opacity: 0 },
           }}
         >
           {!largeMobile && project.img && (
@@ -194,7 +262,12 @@ const ProjectCard = ({
               sx={{
                 width: '100%',
                 aspectRatio: '16 / 9',
+                // `contain`, not `cover`: two of these are logos and one is a
+                // marketplace listing, all of which lose their subject when
+                // cropped. The tinted panel behind makes the resulting
+                // letterboxing look deliberate rather than like a gap.
                 objectFit: 'contain',
+                bgcolor: 'action.hover',
               }}
             />
           )}
@@ -217,14 +290,43 @@ const ProjectCard = ({
               />
             </Box>
           )}
-          <CardContent sx={{ width: '100%' }}>
-            <Typography gutterBottom variant="h5" component="div">
+          <CardContent
+            sx={{ width: '100%', flexGrow: 1, display: 'flex', flexDirection: 'column' }}
+          >
+            <Typography
+              variant="h6"
+              component="div"
+              sx={{
+                fontWeight: 600,
+                // No `gutterBottom`: the reserved two lines below already
+                // separate the title from the body on one-line names.
+                // Always two lines' worth of space, clamped at two. "Game
+                // Competition Website" wraps where the other three names don't,
+                // which started its description a line lower than its
+                // neighbours'; reserving the space lines every card's body up.
+                lineHeight: 1.3,
+                minHeight: '2.6em',
+                display: '-webkit-box',
+                WebkitBoxOrient: 'vertical',
+                WebkitLineClamp: 2,
+                overflow: 'hidden',
+              }}
+            >
               {project.name}
             </Typography>
             <Typography
               variant="body2"
               sx={{
                 color: 'text.secondary',
+                // Two lines, then ellipsis. Descriptions run from 50 to 130
+                // characters, which was most of the height difference between
+                // cards -- and the live API can replace one with a longer repo
+                // description at any time, so capping it keeps the row tidy
+                // without depending on anyone writing to a length.
+                display: '-webkit-box',
+                WebkitBoxOrient: 'vertical',
+                WebkitLineClamp: 2,
+                overflow: 'hidden',
               }}
             >
               {project.description}
@@ -240,7 +342,11 @@ const ProjectCard = ({
                   alignItems: 'center',
                   flexWrap: 'wrap',
                   color: 'text.secondary',
-                  mt: 1,
+                  // Pinned to the bottom of the stretched card so the metadata
+                  // rows line up across a row instead of floating at whatever
+                  // height each description happens to end at.
+                  mt: 'auto',
+                  pt: 1,
                 }}
               >
                 {project.live.language && (
@@ -272,20 +378,12 @@ const ProjectCard = ({
  * stay on screen a while -- it needs to read as "loading", not "broken".
  */
 const ProjectCardSkeleton = ({ largeMobile }: { largeMobile: boolean }) => (
-  <Grid
-    data-testid="project-grid-item"
-    size={{
-      xs: 12,
-      sm: 6,
-      md: 4,
-      lg: 4,
-      xl: 4,
-    }}
-  >
-    <Card sx={{ width: '100%', bgcolor: 'background.default', overflow: 'visible' }}>
+  <Grid data-testid="project-grid-item" sx={{ display: 'flex' }} size={PROJECT_GRID_SIZE}>
+    <Card sx={projectCardSx}>
       <Box
         sx={{
           width: '100%',
+          flexGrow: 1,
           display: 'flex',
           flexDirection: 'column',
         }}
@@ -294,7 +392,9 @@ const ProjectCardSkeleton = ({ largeMobile }: { largeMobile: boolean }) => (
           <Skeleton variant="rectangular" width="100%" sx={{ aspectRatio: '16 / 9' }} />
         )}
         <CardContent sx={{ width: '100%' }}>
-          <Skeleton variant="text" width="60%" height={32} />
+          {/* Two description lines, matching ProjectCard's clamp, so the swap
+              from skeleton to card doesn't change the card's height. */}
+          <Skeleton variant="text" width="60%" height={28} />
           <Skeleton variant="text" width="90%" />
           <Skeleton variant="text" width="75%" />
         </CardContent>

--- a/frontend/src/components/Pages/Projects/Projects.tsx
+++ b/frontend/src/components/Pages/Projects/Projects.tsx
@@ -22,16 +22,26 @@ import { useScrollReveal } from '../../../hooks/useScrollReveal';
 
 /**
  * Narrowest a card may get before the grid drops a column. Everything about the
- * section's density follows from this one number.
+ * section's density follows from this one number, and it is the only knob worth
+ * turning here.
  *
  * Deliberately an `auto-fill` grid rather than fixed breakpoint columns. Fixed
  * columns pin the count -- `lg: 3` meant four per row and no more, so every
  * project added past the fourth became a new *row*, and the section outgrew a
  * laptop viewport at eight. Auto-fill spends extra width on more columns
- * instead: 5 on a 1366px laptop, 7 at 1920, 10 at 2560. Adding projects fills
- * the row that is already there before it starts a second one.
+ * instead, so new projects fill the row that already exists first.
+ *
+ * 230 specifically, because the column count snaps and the useful values are
+ * few. Measured at 1366x768, the tightest screen that matters here:
+ *
+ *   min 200 -> 6 columns, 201px cards -- too small
+ *   min 230 -> 5 columns, 244px cards -- eight projects still fit one screen
+ *   min 250 -> 4 columns, 310px cards -- eight projects overflow by 52px
+ *
+ * So 230 is the widest card that keeps a second row on screen at 1366. Going
+ * wider costs a column, and a lost column costs a whole row.
  */
-const PROJECT_CARD_MIN_WIDTH = 200;
+const PROJECT_CARD_MIN_WIDTH = 230;
 
 /**
  * The card shell, shared with the skeleton. The border is doing real work

--- a/frontend/src/components/Pages/Projects/Projects.tsx
+++ b/frontend/src/components/Pages/Projects/Projects.tsx
@@ -4,7 +4,6 @@ import {
   CardContent,
   CardHeader,
   CardMedia,
-  Grid,
   IconButton,
   Skeleton,
   Stack,
@@ -22,19 +21,17 @@ import useProjects, { type ApiProject } from './useProjects';
 import { useScrollReveal } from '../../../hooks/useScrollReveal';
 
 /**
- * One column split, shared by the real card and its skeleton so the two can
- * never drift and cause the swap to jump. Four across on a wide screen, which
- * is what the current project count fills exactly -- at `md: 4` the fourth card
- * wrapped onto a row of its own and sat there centred, looking like a mistake.
+ * Narrowest a card may get before the grid drops a column. Everything about the
+ * section's density follows from this one number.
+ *
+ * Deliberately an `auto-fill` grid rather than fixed breakpoint columns. Fixed
+ * columns pin the count -- `lg: 3` meant four per row and no more, so every
+ * project added past the fourth became a new *row*, and the section outgrew a
+ * laptop viewport at eight. Auto-fill spends extra width on more columns
+ * instead: 5 on a 1366px laptop, 7 at 1920, 10 at 2560. Adding projects fills
+ * the row that is already there before it starts a second one.
  */
-const PROJECT_GRID_SIZE = { xs: 12, sm: 6, md: 4, lg: 3 };
-
-/**
- * Caps how wide the grid may get. On a 1918px window the cards were 602px wide
- * with a 339px image -- one project taking up most of the screen. The section
- * card itself still spans the full width; only the grid inside it is bounded.
- */
-const PROJECT_GRID_MAX_WIDTH = 1200;
+const PROJECT_CARD_MIN_WIDTH = 200;
 
 /**
  * The card shell, shared with the skeleton. The border is doing real work
@@ -143,29 +140,25 @@ const Projects = () => {
             width: '100%',
             height: '100%',
             display: 'flex',
-            // The grid is width-capped, so this positions the capped box itself
-            // -- centring it here is what pushed the cards away from the
-            // section's left-aligned heading.
             justifyContent: 'flex-start',
-            alignItems: 'center',
+            alignItems: 'flex-start',
             flexGrow: 1,
           }}
         >
-          <Grid
-            container
-            spacing={2}
+          <Box
             ref={cards.ref}
             sx={[
               {
                 width: '100%',
-                maxWidth: PROJECT_GRID_MAX_WIDTH,
-                // Left-aligned rather than centred: the section's "Projects"
-                // heading sits at the left edge, and a centred grid inside a
-                // full-width section card left a wide gutter that made the
-                // cards look detached from their own heading.
-                justifyContent: 'flex-start',
-                // Every card in a row gets the row's height; see the Grid item
-                // in ProjectCard for why this matters.
+                display: 'grid',
+                // `auto-fill` (not `auto-fit`): with few projects on a very wide
+                // screen, auto-fit would stretch them to fill the row and undo
+                // the whole point of a compact card. auto-fill keeps the column
+                // width and leaves the empty tracks empty.
+                gridTemplateColumns: `repeat(auto-fill, minmax(${PROJECT_CARD_MIN_WIDTH}px, 1fr))`,
+                gap: 2,
+                // CSS grid stretches items to their row's height on its own, so
+                // cards line up without the flex plumbing this needed before.
                 alignItems: 'stretch',
               },
               cards.sx,
@@ -178,7 +171,7 @@ const Projects = () => {
               : displayProjects.map((project) => (
                   <ProjectCard key={project.repoName} project={project} largeMobile={largeMobile} />
                 ))}
-          </Grid>
+          </Box>
         </CardContent>
       </Card>
     </Stack>
@@ -195,15 +188,13 @@ const ProjectCard = ({
   const updatedAt = project.live?.updatedAt ? formatUpdatedAt(project.live.updatedAt) : null;
 
   return (
-    <Grid
+    <Box
       data-testid="project-grid-item"
-      // `display: flex` is what lets the Card below stretch to the height of
-      // the tallest card in its row. Without it each card sized to its own
-      // content and the row bottoms came out ragged -- 20px apart on desktop
-      // and 72px on mobile, where a two-line description on one card and a
-      // one-line on the next is the whole difference.
+      // `display: flex` is what passes the grid row's height down to the Card.
+      // Without it each card sized to its own content and the row bottoms came
+      // out ragged -- 20px apart on desktop and 72px on mobile, where a
+      // two-line description against a one-line one is the whole difference.
       sx={{ display: 'flex' }}
-      size={PROJECT_GRID_SIZE}
     >
       {/* Still no fixed height on the card -- `height: 300` plus a `height:
           '50%'` image and a `maxHeight: '60%'` CardContent once looked like a
@@ -261,7 +252,12 @@ const ProjectCard = ({
               loading="lazy"
               sx={{
                 width: '100%',
-                aspectRatio: '16 / 9',
+                // 2:1 rather than the images' own 16:9. The image is the single
+                // biggest contributor to card height, and height is what
+                // decides whether a second row of projects still fits on one
+                // screen: at 16:9 two rows came to 665px against the 657px a
+                // 1366x768 laptop actually has. This buys back ~13px a card.
+                aspectRatio: '2 / 1',
                 // `contain`, not `cover`: two of these are logos and one is a
                 // marketplace listing, all of which lose their subject when
                 // cropped. The tinted panel behind makes the resulting
@@ -275,7 +271,9 @@ const ProjectCard = ({
             <Box
               sx={{
                 width: '100%',
-                aspectRatio: '16 / 9',
+                // Matches the real image's ratio so a project without a
+                // screenshot is the same height as one with.
+                aspectRatio: '2 / 1',
                 display: 'flex',
                 justifyContent: 'center',
                 alignItems: 'center',
@@ -284,19 +282,32 @@ const ProjectCard = ({
             >
               <CodeIcon
                 sx={{
-                  fontSize: 120,
+                  // Was 120px, set when the image box was 339px tall; it
+                  // now overflows a ~100px box.
+                  fontSize: 56,
                   color: 'action.disabled',
                 }}
               />
             </Box>
           )}
           <CardContent
-            sx={{ width: '100%', flexGrow: 1, display: 'flex', flexDirection: 'column' }}
+            sx={{
+              width: '100%',
+              flexGrow: 1,
+              display: 'flex',
+              flexDirection: 'column',
+              // Tighter than MUI's default 16px/24px. At a 200px column that
+              // padding was a meaningful share of the card's width.
+              p: 1.5,
+              '&:last-child': { pb: 1.5 },
+            }}
           >
             <Typography
-              variant="h6"
+              variant="subtitle1"
               component="div"
               sx={{
+                // `h6` (20px) was set when cards were 288px wide; at 200px it
+                // pushed most names onto the second line.
                 fontWeight: 600,
                 // No `gutterBottom`: the reserved two lines below already
                 // separate the title from the body on one-line names.
@@ -368,7 +379,7 @@ const ProjectCard = ({
           </CardContent>
         </CardActionArea>
       </Card>
-    </Grid>
+    </Box>
   );
 };
 
@@ -378,7 +389,7 @@ const ProjectCard = ({
  * stay on screen a while -- it needs to read as "loading", not "broken".
  */
 const ProjectCardSkeleton = ({ largeMobile }: { largeMobile: boolean }) => (
-  <Grid data-testid="project-grid-item" sx={{ display: 'flex' }} size={PROJECT_GRID_SIZE}>
+  <Box data-testid="project-grid-item" sx={{ display: 'flex' }}>
     <Card sx={projectCardSx}>
       <Box
         sx={{
@@ -389,7 +400,7 @@ const ProjectCardSkeleton = ({ largeMobile }: { largeMobile: boolean }) => (
         }}
       >
         {!largeMobile && (
-          <Skeleton variant="rectangular" width="100%" sx={{ aspectRatio: '16 / 9' }} />
+          <Skeleton variant="rectangular" width="100%" sx={{ aspectRatio: '2 / 1' }} />
         )}
         <CardContent sx={{ width: '100%' }}>
           {/* Two description lines, matching ProjectCard's clamp, so the swap
@@ -400,7 +411,7 @@ const ProjectCardSkeleton = ({ largeMobile }: { largeMobile: boolean }) => (
         </CardContent>
       </Box>
     </Card>
-  </Grid>
+  </Box>
 );
 
 export default Projects;


### PR DESCRIPTION
Three reported problems, all measured before and after at 1918x918.

| | before | after |
|---|---:|---:|
| card size (desktop) | 602 x 479 | **288 x 322** |
| image height | 339px | **161px** |
| height spread, desktop | 20px | **0px** |
| height spread, mobile | 72px | **0px** |
| section height | 1068px (1.2 viewports) | **436px (0.5)** |

### The cards were enormous

The image alone was 71% of the card. Fixed with a 1200px cap on the grid (the section card still spans full width — only the grid inside it is bounded), `lg: 3` so four projects fill one row, and the title dropped from `h5` to `h6`. At `md: 4` the fourth card wrapped onto a row of its own and sat there centred, which read as a mistake rather than a layout.

### They were different heights

The Grid item is now a flex container so the Card stretches to the row height, the description is clamped to two lines, and the metadata row is pinned to the bottom with `mt: auto` so those align too. The title reserves two lines' worth of space and clamps at two, so every card's body starts at the same height even though "Game Competition Website" wraps and the other three names don't.

### The hover was invisible in the light theme

MUI's default is a flat tint of `text.primary` — 4% black on the light theme's near-white card, against 8% white on dark. Replaced with a `primary.main` border, a 4px lift and a shadow. `primary` is defined per theme, so one rule works in all six:

| theme | hover border vs card |
|---|---:|
| dark | 5.60:1 |
| blue | 6.36:1 |
| light | 5.65:1 |
| red | 9.75:1 |
| purple | 8.72:1 |
| green | 10.32:1 |

All well clear of the 3:1 floor for UI components. The default highlight is neutralised; the focus-visible ring is untouched, as it comes from the shared `MuiButtonBase` override rather than from this highlight.

### Found while in here

- The cards had **no visible edge in the light theme** (`#f4f5f7` on white paper), so they read as screenshots floating on the page. They now carry a divider border, which the hover state recolours.
- The grid was **centred inside a full-width section whose heading is left-aligned**, leaving a gutter that detached the cards from their own heading. It now starts at the same left edge.

Card and skeleton share the column split and the card shell, so the loading swap cannot jump.

## Verification

93 unit tests, 9 e2e, lint and `tsc --noEmit` clean. Measured in a browser across all six themes plus mobile at 390px, where the cards drop their images and still come out identical.